### PR TITLE
refactor(vpc): make module reusable via git source

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,8 @@
 locals {
-  tags = {
-    Department   = "DevOps"
-    Organization = "Infrastructure and Operations"
-    Environment  = "Dev"
-    ManagedBy    = "Terraform"
-  }
+  tags = merge(
+    var.tags,
+    {
+      ManagedBy = "Terraform"
+    }
+  )
 }

--- a/modules.tf
+++ b/modules.tf
@@ -4,7 +4,7 @@ module "vpc" {
   project_name           = var.project_name
   newbits_private_subnet = var.newbits_private_subnet
   newbits_public_subnet  = var.newbits_public_subnet
-  ngw_public_subnet_id   = module.vpc.ngw_public_subnet_id
+  az_count               = var.az_count
   tags                   = local.tags
 }
 
@@ -14,7 +14,7 @@ module "route" {
   vpc_id            = module.vpc.vpc_id
   igw_id            = module.vpc.igw_id
   ngw_id            = module.vpc.ngw_id
-  public_subnet_id  = module.vpc.public_subnet_id
-  private_subnet_id = module.vpc.private_subnet_id
+  public_subnet_id  = module.vpc.public_subnet_ids
+  private_subnet_id = module.vpc.private_subnet_ids
   tags              = local.tags
 }

--- a/modules/route/output.tf
+++ b/modules/route/output.tf
@@ -1,7 +1,9 @@
 output "private_rtb_id" {
-  value = aws_route_table.private_rtb.id
+  value       = aws_route_table.private_rtb.id
+  description = "The ID of the private route table"
 }
 
 output "public_rtb_id" {
-  value = aws_route_table.public_rtb.id
+  value       = aws_route_table.public_rtb.id
+  description = "The ID of the public route table"
 }

--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -11,9 +11,9 @@ output "ngw_id" {
 }
 
 output "ngw_public_subnet_id" {
-  value = tomap({
-    for i, subnet in aws_subnet.public_subnet : i => subnet.id
-  })["us-east-1a"]
+  value = values(tomap({
+    for i, subnet in aws_subnet.public_subnet : 1 => subnet.id
+  }))[0]
 }
 
 output "public_subnet_id" {

--- a/modules/vpc/output.tf
+++ b/modules/vpc/output.tf
@@ -1,29 +1,28 @@
 output "vpc_id" {
-  value = aws_vpc.this.id
+  value       = aws_vpc.this.id
+  description = "The ID of the VPC"
 }
 
 output "igw_id" {
-  value = aws_internet_gateway.this.id
+  value       = aws_internet_gateway.this.id
+  description = "The ID of the Internet Gateway"
 }
 
 output "ngw_id" {
-  value = aws_nat_gateway.this.id
+  value       = aws_nat_gateway.this.id
+  description = "The ID of the NAT Gateway"
 }
 
-output "ngw_public_subnet_id" {
-  value = values(tomap({
-    for i, subnet in aws_subnet.public_subnet : 1 => subnet.id
-  }))[0]
-}
-
-output "public_subnet_id" {
-  value = tomap({
+output "public_subnet_ids" {
+  value = {
     for i, public_subnet_id in aws_subnet.public_subnet : i => public_subnet_id.id
-  })
+  }
+  description = "Map of Availability Zone name to public subnet ID"
 }
 
-output "private_subnet_id" {
-  value = tomap({
+output "private_subnet_ids" {
+  value = {
     for i, private_subnet_id in aws_subnet.private_subnet : i => private_subnet_id.id
-  })
+  }
+  description = "Map of Availability Zone name to private subnet ID"
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -25,24 +25,6 @@ variable "vpc_dns_support" {
   description = "Enable DNS resolution via Amazon-provided DNS. Required for EKS"
 }
 
-variable "private_subnet_numbers" {
-  type = map(number)
-  default = {
-    "us-east-1a" = 0
-    "us-east-1b" = 1
-  }
-  description = "Map of availability zones to numbers for private subnet creation"
-}
-
-variable "public_subnet_numbers" {
-  type = map(number)
-  default = {
-    "us-east-1a" = 2
-    "us-east-1b" = 3
-  }
-  description = "Map of availability zones to numbers for public subnet creation"
-}
-
 variable "newbits_private_subnet" {
   type        = number
   description = "Number of additional bits to extend the VPC CIDR for private subnets"
@@ -53,7 +35,12 @@ variable "newbits_public_subnet" {
   description = "Number of additional bits to extend the VPC CIDR for public subnets"
 }
 
-variable "ngw_public_subnet_id" {
-  type        = string
-  description = "ID of the public subnet to associate with the NAT gateway"
+variable "az_count" {
+  type        = number
+  description = "Number of Availability Zones to spread subnets across"
+
+  validation {
+    condition     = contains([2, 3], var.az_count)
+    error_message = "az_count must be 2 or 3."
+  }
 }

--- a/modules/vpc/vpc.tf
+++ b/modules/vpc/vpc.tf
@@ -1,3 +1,11 @@
+data "aws_availability_zones" "available_azs" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available_azs.names, 0, var.az_count)
+}
+
 resource "aws_vpc" "this" {
   cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = var.vpc_dns_hostnames
@@ -12,11 +20,11 @@ resource "aws_vpc" "this" {
 }
 
 resource "aws_subnet" "private_subnet" {
-  for_each          = var.private_subnet_numbers
+  for_each          = toset(local.azs)
   vpc_id            = aws_vpc.this.id
   availability_zone = each.key
 
-  cidr_block = cidrsubnet(aws_vpc.this.cidr_block, var.newbits_private_subnet, each.value)
+  cidr_block = cidrsubnet(aws_vpc.this.cidr_block, var.newbits_private_subnet, index(local.azs, each.key) + var.az_count)
 
   tags = merge(
     var.tags,
@@ -30,11 +38,11 @@ resource "aws_subnet" "private_subnet" {
 }
 
 resource "aws_subnet" "public_subnet" {
-  for_each          = var.public_subnet_numbers
+  for_each          = toset(local.azs)
   vpc_id            = aws_vpc.this.id
   availability_zone = each.key
 
-  cidr_block = cidrsubnet(aws_vpc.this.cidr_block, var.newbits_public_subnet, each.value)
+  cidr_block = cidrsubnet(aws_vpc.this.cidr_block, var.newbits_public_subnet, index(local.azs, each.key))
 
   tags = merge(
     var.tags,
@@ -69,8 +77,9 @@ resource "aws_eip" "this" {
 }
 
 resource "aws_nat_gateway" "this" {
-  subnet_id     = var.ngw_public_subnet_id
+  subnet_id     = aws_subnet.public_subnet[local.azs[0]].id
   allocation_id = aws_eip.this.id
+  depends_on    = [aws_internet_gateway.this]
 
   tags = merge(
     var.tags,

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  value       = module.vpc.vpc_id
+  description = "The ID of the VPC"
+}
+
+output "igw_id" {
+  value       = module.vpc.igw_id
+  description = "The ID of the Internet Gateway"
+}
+
+output "ngw_id" {
+  value       = module.vpc.ngw_id
+  description = "The ID of the NAT Gateway"
+}
+
+output "public_subnet_ids" {
+  value       = module.vpc.public_subnet_ids
+  description = "Map of Availability Zone name to public subnet ID"
+}
+
+output "private_subnet_ids" {
+  value       = module.vpc.private_subnet_ids
+  description = "Map of Availability Zone name to private subnet ID"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,8 @@ variable "newbits_public_subnet" {
   type        = number
   description = "Number of additional bits to extend the VPC CIDR for public subnets"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all resources"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,13 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources"
 }
+
+variable "az_count" {
+  type        = number
+  description = "Number of Availability Zones to spread subnets across"
+
+  validation {
+    condition     = contains([2, 3], var.az_count)
+    error_message = "az_count must be 2 or 3."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,16 +3,6 @@ variable "project_name" {
   description = "Name of the project used to prefix resource names"
 }
 
-variable "region_id" {
-  type        = string
-  description = "The AWS region where resources will be provisioned"
-}
-
-variable "cli_profile" {
-  type        = string
-  description = "The AWS CLI profile to use for authentication and access"
-}
-
 variable "vpc_cidr_block" {
   type        = string
   description = "The IPv4 CIDR block to assign to the VPC"


### PR DESCRIPTION
Set of changes to transform the module from a root module into a reusable module consumable via git source.

- chore(vpc)!: remove variables used only by removed provider
- feat(vpc)!: add var.tags to replace hardcoded tag values
- fix(vpc): remove hardcoded availability zone from output
- fix(vpc)!: replace static AZ maps with data source and az_count
- feat(vpc): add outputs for vpc id, subnet ids and gateway